### PR TITLE
Use label instead env, cleanup build

### DIFF
--- a/hassio/const.py
+++ b/hassio/const.py
@@ -30,6 +30,10 @@ LABEL_VERSION = 'io.hass.version'
 LABEL_ARCH = 'io.hass.arch'
 LABEL_TYPE = 'io.hass.type'
 
+META_ADDON = 'addon'
+META_SUPERVISOR = 'supervisor'
+META_HOMEASSISTANT = 'homeassistant'
+
 JSON_RESULT = 'result'
 JSON_DATA = 'data'
 JSON_MESSAGE = 'message'

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -27,7 +27,7 @@ SOCKET_DOCKER = Path("/var/run/docker.sock")
 SOCKET_HC = Path("/var/run/hassio-hc.sock")
 
 LABEL_VERSION = 'io.hass.version'
-LABEL_ARCH= 'io.hass.arch'
+LABEL_ARCH = 'io.hass.arch'
 
 JSON_RESULT = 'result'
 JSON_DATA = 'data'

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -28,6 +28,7 @@ SOCKET_HC = Path("/var/run/hassio-hc.sock")
 
 LABEL_VERSION = 'io.hass.version'
 LABEL_ARCH = 'io.hass.arch'
+LABEL_TYPE = 'io.hass.type'
 
 JSON_RESULT = 'result'
 JSON_DATA = 'data'

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -26,6 +26,8 @@ FILE_HASSIO_CONFIG = Path(HASSIO_SHARE, "config.json")
 SOCKET_DOCKER = Path("/var/run/docker.sock")
 SOCKET_HC = Path("/var/run/hassio-hc.sock")
 
+LABEL_VERSION = 'io.hass.version'
+
 JSON_RESULT = 'result'
 JSON_DATA = 'data'
 JSON_MESSAGE = 'message'

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -27,6 +27,7 @@ SOCKET_DOCKER = Path("/var/run/docker.sock")
 SOCKET_HC = Path("/var/run/hassio-hc.sock")
 
 LABEL_VERSION = 'io.hass.version'
+LABEL_ARCH= 'io.hass.arch'
 
 JSON_RESULT = 'result'
 JSON_DATA = 'data'

--- a/hassio/dock/__init__.py
+++ b/hassio/dock/__init__.py
@@ -40,7 +40,7 @@ class DockerBase(object):
             return
 
         # read metadata
-        metadata =  metadata or self.container
+        metadata = metadata or self.container
         if LABEL_VERSION in metadata['Label']:
             self.version = metadata['Label'][LABEL_VERSION]
 

--- a/hassio/dock/__init__.py
+++ b/hassio/dock/__init__.py
@@ -41,8 +41,8 @@ class DockerBase(object):
 
         # read metadata
         metadata = metadata or self.container
-        if LABEL_VERSION in metadata['Label']:
-            self.version = metadata['Label'][LABEL_VERSION]
+        if LABEL_VERSION in metadata['Config']['Label']:
+            self.version = metadata['Config']['Label'][LABEL_VERSION]
 
         # dedicated
         self.version = get_version_from_env(metadata['Config']['Env'])

--- a/hassio/dock/__init__.py
+++ b/hassio/dock/__init__.py
@@ -40,9 +40,9 @@ class DockerBase(object):
             return
 
         # read metadata
-        metadata = metadata or self.container
-        if LABEL_VERSION in metadata['Config']['Label']:
-            self.version = metadata['Config']['Label'][LABEL_VERSION]
+        metadata = metadata or self.container.attrs
+        if LABEL_VERSION in metadata['Config']['Labels']:
+            self.version = metadata['Config']['Labels'][LABEL_VERSION]
 
         # dedicated
         self.version = get_version_from_env(metadata['Config']['Env'])

--- a/hassio/dock/__init__.py
+++ b/hassio/dock/__init__.py
@@ -43,9 +43,9 @@ class DockerBase(object):
         metadata = metadata or self.container.attrs
         if LABEL_VERSION in metadata['Config']['Labels']:
             self.version = metadata['Config']['Labels'][LABEL_VERSION]
-
-        # dedicated
-        self.version = get_version_from_env(metadata['Config']['Env'])
+        else:
+            # dedicated
+            self.version = get_version_from_env(metadata['Config']['Env'])
 
     async def install(self, tag):
         """Pull docker image."""

--- a/hassio/dock/__init__.py
+++ b/hassio/dock/__init__.py
@@ -36,7 +36,7 @@ class DockerBase(object):
 
     def process_metadata(self, metadata=None, force=False):
         """Read metadata and set it to object."""
-        if not force and version:
+        if not force and self.version:
             return
 
         # read metadata

--- a/hassio/dock/addon.py
+++ b/hassio/dock/addon.py
@@ -7,6 +7,7 @@ import docker
 
 from . import DockerBase
 from .util import dockerfile_template
+from ..const import META_ADDON
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,7 +144,8 @@ class DockerAddon(DockerBase):
             # prepare Dockerfile
             try:
                 dockerfile_template(
-                    Path(build_dir, 'Dockerfile'), self.addons_data.arch, tag)
+                    Path(build_dir, 'Dockerfile'), self.addons_data.arch,
+                    tag, META_ADDON)
             except OSError as err:
                 _LOGGER.error("Can't prepare dockerfile -> %s", err)
 

--- a/hassio/dock/homeassistant.py
+++ b/hassio/dock/homeassistant.py
@@ -4,7 +4,6 @@ import logging
 import docker
 
 from . import DockerBase
-from ..tools import get_version_from_env
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/hassio/dock/homeassistant.py
+++ b/hassio/dock/homeassistant.py
@@ -51,8 +51,7 @@ class DockerHomeAssistant(DockerBase):
                         {'bind': '/ssl', 'mode': 'rw'},
                 })
 
-            self.version = get_version_from_env(
-                self.container.attrs['Config']['Env'])
+            self.process_metadata()
 
             _LOGGER.info("Start docker addon %s with version %s",
                          self.image, self.version)

--- a/hassio/dock/util.py
+++ b/hassio/dock/util.py
@@ -11,7 +11,6 @@ RESIN_BASE_IMAGE = {
     ARCH_AMD64: "resin/amd64-alpine:3.5",
 }
 
-TMPL_VERSION = re.compile(r"%%VERSION%%")
 TMPL_IMAGE = re.compile(r"%%BASE_IMAGE%%")
 
 
@@ -23,10 +22,17 @@ def dockerfile_template(dockerfile, arch, version):
     # read docker
     with dockerfile.open('r') as dock_input:
         for line in dock_input:
-            line = TMPL_VERSION.sub(version, line)
             line = TMPL_IMAGE.sub(resin_image, line)
             buff.append(line)
+
+    # add metadata
+    buff.append(create_metadata(version, arch))
 
     # write docker
     with dockerfile.open('w') as dock_output:
         dock_output.writelines(buff)
+
+
+def create_metadata(version, arch):
+    """Generate docker label layer for hassio."""
+    return "LABEL io.hass.version={} io.hass.arch={}".format(version, arch)

--- a/hassio/dock/util.py
+++ b/hassio/dock/util.py
@@ -35,4 +35,4 @@ def dockerfile_template(dockerfile, arch, version):
 
 def create_metadata(version, arch):
     """Generate docker label layer for hassio."""
-    return "LABEL io.hass.version={} io.hass.arch={}".format(version, arch)
+    return 'LABEL io.hass.version="{}" io.hass.arch="{}"'.format(version, arch)

--- a/hassio/dock/util.py
+++ b/hassio/dock/util.py
@@ -35,4 +35,6 @@ def dockerfile_template(dockerfile, arch, version):
 
 def create_metadata(version, arch):
     """Generate docker label layer for hassio."""
-    return 'LABEL io.hass.version="{}" io.hass.arch="{}"'.format(version, arch)
+    return ('LABEL io.hass.version="{}" '
+            'io.hass.arch="{}" '
+            'io.hass.type="addon"').format(version, arch)

--- a/hassio/dock/util.py
+++ b/hassio/dock/util.py
@@ -14,7 +14,7 @@ RESIN_BASE_IMAGE = {
 TMPL_IMAGE = re.compile(r"%%BASE_IMAGE%%")
 
 
-def dockerfile_template(dockerfile, arch, version):
+def dockerfile_template(dockerfile, arch, version, meta_type):
     """Prepare a Hass.IO dockerfile."""
     buff = []
     resin_image = RESIN_BASE_IMAGE[arch]
@@ -26,15 +26,15 @@ def dockerfile_template(dockerfile, arch, version):
             buff.append(line)
 
     # add metadata
-    buff.append(create_metadata(version, arch))
+    buff.append(create_metadata(version, arch, meta_type))
 
     # write docker
     with dockerfile.open('w') as dock_output:
         dock_output.writelines(buff)
 
 
-def create_metadata(version, arch):
+def create_metadata(version, arch, meta_type):
     """Generate docker label layer for hassio."""
     return ('LABEL io.hass.version="{}" '
             'io.hass.arch="{}" '
-            'io.hass.type="addon"').format(version, arch)
+            'io.hass.type="{}"').format(version, arch, meta_type)


### PR DESCRIPTION
- This code allow user to use every dockerfile without change for hass.io
- Cleanup wired version tracking code
- Make build system more robust