### PR TITLE
Allow privileged capability SYS_RAWIO

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -38,6 +38,7 @@ STARTUP_ALL = [
 PRIVILEGED_ALL = [
     "NET_ADMIN",
     "SYS_ADMIN",
+    "SYS_RAWIO"
 ]
 
 


### PR DESCRIPTION
In order to allow writes to /dev/mem, which is needed e.g. to use the
GPIO ports on Raspberry Pi, the SYS_RAWIO capability needs to be
granted.

Fixes #134.

**NOTE:** I haven't been able to test this, so please verify it as you please before merging :)