### PR TITLE
Recursively git clone addon repositories, allowing submodules

### DIFF
--- a/hassio/addons/git.py
+++ b/hassio/addons/git.py
@@ -48,7 +48,8 @@ class GitRepo(object):
             try:
                 _LOGGER.info("Clone addon %s repository", self.url)
                 self.repo = await self.loop.run_in_executor(
-                    None, git.Repo.clone_from, self.url, str(self.path))
+                    None, git.Repo.clone_from, self.url, str(self.path),
+                    recursive=True)
 
             except (git.InvalidGitRepositoryError, git.NoSuchPathError,
                     git.GitCommandError) as err:


### PR DESCRIPTION
## Proposed Change

Cloning GIT repositories, containing hass.io add-ons, recursively, allowing the use of GIT submodules in those add-on repositories.

## Motivation

Imagine maintaining a large add-on repository, with all kinds of plugins. The issue tracker of this repository would possibly contain all kinds of stuff, a big mix of issues for all those different add-ons.

Using submodules an add-ons repository maintainer could separate the actual add-on from the repository. This would potentially help with issue tracking separation, but also with things like testing.
