### PR TITLE
Remove support for custom configs / configs for other hass.io versions

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -113,7 +113,7 @@ SCHEMA_REPOSITORY_CONFIG = vol.Schema({
     vol.Required(ATTR_NAME): vol.Coerce(str),
     vol.Optional(ATTR_URL): vol.Url(),
     vol.Optional(ATTR_MAINTAINER): vol.Coerce(str),
-}, extra=vol.ALLOW_EXTRA)
+})
 
 
 # pylint: disable=no-value-for-parameter

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -105,7 +105,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
     vol.Optional(ATTR_IMAGE): vol.Match(r"^[\-\w{}]+/[\-\w{}]+$"),
     vol.Optional(ATTR_TIMEOUT, default=10):
         vol.All(vol.Coerce(int), vol.Range(min=10, max=120))
-}, extra=vol.ALLOW_EXTRA)
+})
 
 
 # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
We can not care about custom modify config.json and they can make trouble in future changes. This prevent us also to install a addon they config is not supported with the current running hass.io version