### PR TITLE
Allow dynamic handling of proto part

### DIFF
--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -219,7 +219,7 @@ class Addon(object):
 
         # search host port for this docker port
         if self.ports is None:
-            port = self.ports.get("{}/tcp".format(dock_port), t_port)
+            port = self.ports.get("{}/tcp".format(t_port), t_port)
         else:
             port = t_port
 

--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -215,7 +215,7 @@ class Addon(object):
         t_port = webui.group('t_port')
         t_proto = webui.group('t_proto')
         s_prefix = webui.group('s_prefix') or ""
-        s_suffix = webui.group('s_prefix') or ""
+        s_suffix = webui.group('s_suffix') or ""
 
         # search host port for this docker port
         if self.ports is None:

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -86,7 +86,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
         vol.In([BOOT_AUTO, BOOT_MANUAL]),
     vol.Optional(ATTR_PORTS): DOCKER_PORTS,
     vol.Optional(ATTR_WEBUI):
-        vol.Match(r"^(?:https?):\/\/\[HOST\]:\[PORT:\d+\].*$"),
+        vol.Match(r"^(?:https?|\[PROTO:\w+\]):\/\/\[HOST\]:\[PORT:\d+\].*$"),
     vol.Optional(ATTR_HOST_NETWORK, default=False): vol.Boolean(),
     vol.Optional(ATTR_DEVICES): [vol.Match(r"^(.*):(.*):([rwm]{1,3})$")],
     vol.Optional(ATTR_TMPFS):


### PR DESCRIPTION
- support now dynamic lookup for proto: `[PROTO:ssl]://[HOST]:[PORT:80]/login`. This try to lookup `ssl` in options and set `https` if they will be true or `http`