### PR TITLE
Remove dedicated API calls

### DIFF
--- a/API.md
+++ b/API.md
@@ -430,25 +430,9 @@ For reset custom network/audio settings, set it `null`.
 
 - POST `/addons/{addon}/install`
 
-Optional:
-
-```json
-{
-    "version": "VERSION"
-}
-```
-
 - POST `/addons/{addon}/uninstall`
 
 - POST `/addons/{addon}/update`
-
-Optional:
-
-```json
-{
-    "version": "VERSION"
-}
-```
 
 - GET `/addons/{addon}/logs`
 

--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -447,7 +447,7 @@ class Addon(object):
             return False
         return True
 
-    async def install(self, version=None):
+    async def install(self):
         """Install a addon."""
         if self.config.arch not in self.supported_arch:
             _LOGGER.error(
@@ -463,11 +463,10 @@ class Addon(object):
                 "Create Home-Assistant addon data folder %s", self.path_data)
             self.path_data.mkdir()
 
-        version = version or self.last_version
-        if not await self.docker.install(version):
+        if not await self.docker.install(self.last_version):
             return False
 
-        self._set_install(version)
+        self._set_install(self.last_version)
         return True
 
     @check_installed
@@ -510,19 +509,19 @@ class Addon(object):
         return self.docker.stop()
 
     @check_installed
-    async def update(self, version=None):
+    async def update(self):
         """Update addon."""
         version = version or self.last_version
         last_state = await self.state()
 
-        if version == self.version_installed:
+        if self.last_version == self.version_installed:
             _LOGGER.warning(
-                "Addon %s is already installed in %s", self._id, version)
+                "No update available for Addon %s", self._id)
             return False
 
-        if not await self.docker.update(version):
+        if not await self.docker.update(self.last_version):
             return False
-        self._set_update(version)
+        self._set_update(self.last_version)
 
         # restore state
         if last_state == STATE_STARTED:

--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -511,7 +511,6 @@ class Addon(object):
     @check_installed
     async def update(self):
         """Update addon."""
-        version = version or self.last_version
         last_state = await self.state()
 
         if self.last_version == self.version_installed:

--- a/hassio/api/addons.py
+++ b/hassio/api/addons.py
@@ -166,14 +166,10 @@ class APIAddons(object):
         return True
 
     @api_process
-    async def install(self, request):
+    def install(self, request):
         """Install addon."""
-        body = await api_validate(SCHEMA_VERSION, request)
         addon = self._extract_addon(request, check_installed=False)
-        version = body.get(ATTR_VERSION, addon.last_version)
-
-        return await asyncio.shield(
-            addon.install(version=version), loop=self.loop)
+        return asyncio.shield(addon.install(), loop=self.loop)
 
     @api_process
     def uninstall(self, request):
@@ -204,15 +200,12 @@ class APIAddons(object):
     @api_process
     async def update(self, request):
         """Update addon."""
-        body = await api_validate(SCHEMA_VERSION, request)
         addon = self._extract_addon(request)
-        version = body.get(ATTR_VERSION, addon.last_version)
 
-        if version == addon.version_installed:
-            raise RuntimeError("Version %s is already in use", version)
+        if addon.last_version == addon.version_installed:
+            raise RuntimeError("No update available!")
 
-        return await asyncio.shield(
-            addon.update(version=version), loop=self.loop)
+        return asyncio.shield(addon.update(), loop=self.loop)
 
     @api_process
     def restart(self, request):
@@ -253,4 +246,4 @@ class APIAddons(object):
             raise RuntimeError("STDIN not supported by addons")
 
         data = await request.read()
-        return asyncio.shield(addon.write_stdin(data), loop=self.loop)
+        return await asyncio.shield(addon.write_stdin(data), loop=self.loop)

--- a/hassio/api/addons.py
+++ b/hassio/api/addons.py
@@ -198,7 +198,7 @@ class APIAddons(object):
         return asyncio.shield(addon.stop(), loop=self.loop)
 
     @api_process
-    async def update(self, request):
+    def update(self, request):
         """Update addon."""
         addon = self._extract_addon(request)
 


### PR DESCRIPTION
For tests I had add function to set the version on installation. That was never the idea on the productive system. I forgot to remove this old code.