### PR TITLE
Allow to set a option als optional

### DIFF
--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -8,7 +8,6 @@ import shutil
 import tarfile
 from tempfile import TemporaryDirectory
 
-from deepmerge import Merger
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
@@ -32,8 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 RE_WEBUI = re.compile(
     r"^(?:(?P<s_prefix>https?)|\[PROTO:(?P<t_proto>\w+)\])"
     r":\/\/\[HOST\]:\[PORT:(?P<t_port>\d+)\](?P<s_suffix>.*)$")
-
-MERGE_OPT = Merger([(dict, ['merge'])], ['override'], ['override'])
 
 
 class Addon(object):
@@ -109,10 +106,10 @@ class Addon(object):
     def options(self):
         """Return options with local changes."""
         if self.is_installed:
-            return MERGE_OPT.merge(
-                self.data.system[self._id][ATTR_OPTIONS],
-                self.data.user[self._id][ATTR_OPTIONS],
-            )
+            return {
+                **self.data.system[self._id][ATTR_OPTIONS],
+                **self.data.user[self._id][ATTR_OPTIONS]
+            }
         return self.data.cache[self._id][ATTR_OPTIONS]
 
     @options.setter

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -105,8 +105,9 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
     vol.Required(ATTR_OPTIONS): dict,
     vol.Required(ATTR_SCHEMA): vol.Any(vol.Schema({
         vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [
-            vol.Any(SCHEMA_ELEMENT,
-                    {vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}
+            vol.Any(
+                SCHEMA_ELEMENT,
+                {vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}
             ),
         ], vol.Schema({vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}))
     }), False),

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -288,6 +288,7 @@ def _check_missing_options(origin, exists):
     """Check if all options are exists."""
     missing = set(origin) - set(exists)
     for miss_opt in missing:
-        if isinstance(origin[miss_opt], str) and origin[miss_opt].endswith("?"):
+        if isinstance(origin[miss_opt], str) and \
+                origin[miss_opt].endswith("?"):
             continue
         raise vol.Invalid("Missing {} option inside options".format(miss_opt))

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -38,7 +38,7 @@ RE_SCHEMA_ELEMENT = re.compile(
     r"|int(?:\((?P<i_min>\d+)?,(?P<i_max>\d+)?\))?"
     r"|float(?:\((?P<f_min>[\d\.]+)?,(?P<f_max>[\d\.]+)?\))?"
     r"|match\((?P<match>.*)\)"
-    r")\??)$"
+    r")\??$"
 )
 
 SCHEMA_ELEMENT = vol.Match(RE_SCHEMA_ELEMENT)

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -199,6 +199,7 @@ def validate_options(raw_schema):
                 raise vol.Invalid(
                     "Type error for {}.".format(key)) from None
 
+        _check_missing_options(typ, options)
         return options
 
     return validate
@@ -285,8 +286,8 @@ def _nested_validate_dict(typ, data_dict, key):
 
 def _check_missing_options(origin, exists):
     """Check if all options are exists."""
-    missing = set(typ) - set(exists)
+    missing = set(origin) - set(exists)
     for miss_opt in missing:
-        if typ[miss_opt].endswith("?"):
+        if isinstance(origin[miss_opt], str) and origin[miss_opt].endswith("?"):
             continue
         raise vol.Invalid("Missing {} option inside options".format(miss_opt))

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -204,7 +204,7 @@ def validate_options(raw_schema):
                 raise vol.Invalid(
                     "Type error for {}.".format(key)) from None
 
-        _check_missing_options(typ, options)
+        _check_missing_options(typ, options, 'root')
         return options
 
     return validate
@@ -290,4 +290,4 @@ def _check_missing_options(origin, exists, root):
                 origin[miss_opt].endswith("?"):
             continue
         raise vol.Invalid(
-            "Missing opton {} in {}".format(miss_opt, root))
+            "Missing option {} in {}".format(miss_opt, root))

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -274,7 +274,8 @@ def _nested_validate_dict(typ, data_dict, key):
 
         # Nested?
         if isinstance(typ[c_key], list):
-            options[c_key] = _nested_validate_list(typ[c_key], c_value, c_key)
+            options[c_key] = _nested_validate_list(typ[c_key][0],
+                                                   c_value, c_key)
         else:
             options[c_key] = _single_validate(typ[c_key], c_value, c_key)
 

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -285,7 +285,7 @@ def _nested_validate_dict(typ, data_dict, key):
 
 def _check_missing_options(origin, exists):
     """Check if all options are exists."""
-    missing = set(typ) - set(c_options)
+    missing = set(typ) - set(exists)
     for miss_opt in missing:
         if typ[miss_opt].endswith("?"):
             continue

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -204,7 +204,7 @@ def validate_options(raw_schema):
                 raise vol.Invalid(
                     "Type error for {}.".format(key)) from None
 
-        _check_missing_options(typ, options, 'root')
+        _check_missing_options(raw_schema, options, 'root')
         return options
 
     return validate

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -258,7 +258,7 @@ def _nested_validate_list(typ, data_list, key):
 
                 c_options[c_key] = _single_validate(typ[c_key], c_value, c_key)
 
-            _check_missing_options(typ, options)
+            _check_missing_options(typ, c_options)
             options.append(c_options)
 
         # normal list
@@ -291,4 +291,4 @@ def _check_missing_options(origin, exists):
         if isinstance(origin[miss_opt], str) and \
                 origin[miss_opt].endswith("?"):
             continue
-        raise vol.Invalid("Missing {} option inside options".format(miss_opt))
+        raise vol.Invalid("Missing opton {}".format(miss_opt))

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -109,7 +109,9 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
                 SCHEMA_ELEMENT,
                 {vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}
             ),
-        ], vol.Schema({vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])}))
+        ], vol.Schema({
+            vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [SCHEMA_ELEMENT])
+        }))
     }), False),
     vol.Optional(ATTR_IMAGE): vol.Match(r"^[\-\w{}]+/[\-\w{}]+$"),
     vol.Optional(ATTR_TIMEOUT, default=10):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'pyotp',
         'pyqrcode',
         'pytz',
-        'pyudev',
-        'deepmerge'
+        'pyudev'
     ]
 )


### PR DESCRIPTION
- Allow to set option as optional inside schema with a `?` on the end of type: `str?`
- Remove `deepmerge` and use python3.6 merge to protect merge into wrong storage
- Allow simple lists inside dicts:
```json
{
  "step1": {
    "step_list": ["str"]
  },
  "step_deep": [
    {
      "step_deep_list": ["str"]
    }
  ]
}
```