### PR TITLE
Add support for legacy mode

### DIFF
--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -21,7 +21,7 @@ from ..const import (
     STATE_STARTED, STATE_STOPPED, STATE_NONE, ATTR_USER, ATTR_SYSTEM,
     ATTR_STATE, ATTR_TIMEOUT, ATTR_AUTO_UPDATE, ATTR_NETWORK, ATTR_WEBUI,
     ATTR_HASSIO_API, ATTR_AUDIO, ATTR_AUDIO_OUTPUT, ATTR_AUDIO_INPUT,
-    ATTR_GPIO, ATTR_HOMEASSISTANT_API, ATTR_STDIN)
+    ATTR_GPIO, ATTR_HOMEASSISTANT_API, ATTR_STDIN, ATTR_LEGACY)
 from .util import check_installed
 from ..dock.addon import DockerAddon
 from ..tools import write_json_file, read_json_file
@@ -256,6 +256,11 @@ class Addon(object):
     def privileged(self):
         """Return list of privilege."""
         return self._mesh.get(ATTR_PRIVILEGED)
+
+    @property
+    def legacy(self):
+        """Return if the add-on don't support hass labels."""
+        return self._mesh.get(ATTR_LEGACY)
 
     @property
     def access_hassio_api(self):

--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -15,7 +15,7 @@ from ..const import (
     ATTR_LOCATON, ATTR_REPOSITORY, ATTR_TIMEOUT, ATTR_NETWORK,
     ATTR_AUTO_UPDATE, ATTR_WEBUI, ATTR_AUDIO, ATTR_AUDIO_INPUT,
     ATTR_AUDIO_OUTPUT, ATTR_HASSIO_API, ATTR_BUILD_FROM, ATTR_SQUASH,
-    ATTR_ARGS, ATTR_GPIO, ATTR_HOMEASSISTANT_API, ATTR_STDIN)
+    ATTR_ARGS, ATTR_GPIO, ATTR_HOMEASSISTANT_API, ATTR_STDIN, ATTR_LEGACY)
 from ..validate import NETWORK_PORT, DOCKER_PORTS, ALSA_CHANNEL
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,6 +102,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
     vol.Optional(ATTR_HASSIO_API, default=False): vol.Boolean(),
     vol.Optional(ATTR_HOMEASSISTANT_API, default=False): vol.Boolean(),
     vol.Optional(ATTR_STDIN, default=False): vol.Boolean(),
+    vol.Optional(ATTR_LEGACY, default=False): vol.Boolean(),
     vol.Required(ATTR_OPTIONS): dict,
     vol.Required(ATTR_SCHEMA): vol.Any(vol.Schema({
         vol.Coerce(str): vol.Any(SCHEMA_ELEMENT, [

--- a/hassio/const.py
+++ b/hassio/const.py
@@ -127,6 +127,7 @@ ATTR_SECURITY = 'security'
 ATTR_BUILD_FROM = 'build_from'
 ATTR_SQUASH = 'squash'
 ATTR_GPIO = 'gpio'
+ATTR_LEGACY = 'ATTR_LEGACY'
 ATTR_ADDONS_CUSTOM_LIST = 'addons_custom_list'
 
 STARTUP_INITIALIZE = 'initialize'

--- a/hassio/dock/addon.py
+++ b/hassio/dock/addon.py
@@ -25,6 +25,21 @@ class DockerAddon(DockerInterface):
             config, loop, api, image=addon.image, timeout=addon.timeout)
         self.addon = addon
 
+    def process_metadata(self, metadata, force=False):
+        """Use addon data instead meta data with legacy."""
+        if not self.addon.legacy:
+            return self.process_metadata(metadata, force=force)
+ 
+        # set meta data
+        if not self.version or force:
+            if force:  # called on install/update/build
+                self.version = addon.last_version
+            else:
+                self.version = addon.installed_version
+
+        if not self.arch:
+            self.arch = self.config.arch
+
     @property
     def name(self):
         """Return name of docker container."""

--- a/hassio/dock/addon.py
+++ b/hassio/dock/addon.py
@@ -29,13 +29,13 @@ class DockerAddon(DockerInterface):
         """Use addon data instead meta data with legacy."""
         if not self.addon.legacy:
             return super().process_metadata(metadata, force=force)
- 
+
         # set meta data
         if not self.version or force:
             if force:  # called on install/update/build
-                self.version = addon.last_version
+                self.version = self.addon.last_version
             else:
-                self.version = addon.installed_version
+                self.version = self.addon.installed_version
 
         if not self.arch:
             self.arch = self.config.arch

--- a/hassio/dock/addon.py
+++ b/hassio/dock/addon.py
@@ -28,7 +28,7 @@ class DockerAddon(DockerInterface):
     def process_metadata(self, metadata, force=False):
         """Use addon data instead meta data with legacy."""
         if not self.addon.legacy:
-            return self.process_metadata(metadata, force=force)
+            return super().process_metadata(metadata, force=force)
  
         # set meta data
         if not self.version or force:

--- a/hassio/dock/addon.py
+++ b/hassio/dock/addon.py
@@ -35,7 +35,7 @@ class DockerAddon(DockerInterface):
             if force:  # called on install/update/build
                 self.version = self.addon.last_version
             else:
-                self.version = self.addon.installed_version
+                self.version = self.addon.version_installed
 
         if not self.arch:
             self.arch = self.config.arch


### PR DESCRIPTION
- Add new add-on config options `legacy`. This allow to use docker image without hass.io labels and give full support