### PR TITLE
Re-labeling of "By our self"

### DIFF
--- a/hassio/addons/built-in.json
+++ b/hassio/addons/built-in.json
@@ -2,7 +2,7 @@
     "local": {
         "name": "Local Add-Ons",
         "url": "https://home-assistant.io/hassio",
-        "maintainer": "By our self"
+        "maintainer": "you"
     },
     "core": {
         "name": "Built-in Add-Ons",


### PR DESCRIPTION
# Motivation

Changes it to "you", this improves the display of the maintainer for local add-ons.

# References

Fixes #243