### PR TITLE
Enable probot move

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,13 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment. Ignored when the comment also contains other content
+deleteCommand: true
+# Close the source issue after moving
+closeSourceIssue: true
+# Lock the source issue after moving
+lockSourceIssue: false
+# Set custom aliases for targets
+# aliases:
+#   r: repo
+#   or: owner/repo
+


### PR DESCRIPTION
## Description:
With [ProBot Move Issues](https://probot.github.io/apps/move/) we are able to move an issue around.

Command Syntax:

```text
/move [to ][<owner>/]<repo>
```

This feature is already activate for the main repo, the docs and the Polymer repo.