### PR TITLE
Allow addons that require IPC_LOCK capability

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -60,6 +60,7 @@ PRIVILEGED_ALL = [
     "NET_ADMIN",
     "SYS_ADMIN",
     "SYS_RAWIO",
+    "IPC_LOCK",
     "SYS_TIME",
     "SYS_NICE"
 ]


### PR DESCRIPTION
Currerntly it's not possible to create an addon for pigpiod (the pigpio daemon) because it uses mmap and required the IPC_LOCK capability when running the addon Docker image.

This PR adds support to home-assistant for this.