### PR TITLE
Fix for asound.tmpl

### DIFF
--- a/hassio/host/asound.tmpl
+++ b/hassio/host/asound.tmpl
@@ -6,12 +6,12 @@ pcm.!default {
 pcm.mic {
   type plug
   slave {
-    pcm "hw:{$input}"
+    pcm "hw:$input"
   }
 }
 pcm.speaker {
   type plug
   slave {
-    pcm "hw:{$output}"
+    pcm "hw:$output"
   }
 }


### PR DESCRIPTION
hw identifiers should not have {} around them.

Verified fix with snips addon.