### PR TITLE
Improves audio devices handling

### DIFF
--- a/hassio/misc/hardware.py
+++ b/hassio/misc/hardware.py
@@ -63,6 +63,10 @@ class Hardware(object):
     @property
     def audio_devices(self):
         """Return all available audio interfaces."""
+        if not ASOUND_CARDS.exists():
+            _LOGGER.info("No audio devices found")
+            return {}
+
         try:
             with ASOUND_CARDS.open('r') as cards_file:
                 cards = cards_file.read()


### PR DESCRIPTION
Improves the handling of the search for available audio devices.
On systems without audio devices (and therefore no `asound` installed) the following error is now thrown in the logs:

```
18-05-07 17:14:50 ERROR (MainThread) [hassio.misc.hardware] Can't read asound data: [Errno 2] No such file or directory: '/proc/asound/cards'
```

This PR improves this a little, adding an additional check with a proper matching info log.

**Note**: This change has been dry-coded. I currently do not have a test machine available, nevertheless, the change is trival imho.
