### PR TITLE
[OPI - Armbian] Make seccomp disabled by default

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -108,7 +108,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
     vol.Optional(ATTR_MAP, default=list): [vol.Match(RE_VOLUME)],
     vol.Optional(ATTR_ENVIRONMENT): {vol.Match(r"\w*"): vol.Coerce(str)},
     vol.Optional(ATTR_PRIVILEGED): [vol.In(PRIVILEGED_ALL)],
-    vol.Optional(ATTR_SECCOMP, default=True): vol.Boolean(),
+    vol.Optional(ATTR_SECCOMP, default=False): vol.Boolean(),
     vol.Optional(ATTR_APPARMOR, default=True): vol.Boolean(),
     vol.Optional(ATTR_AUDIO, default=False): vol.Boolean(),
     vol.Optional(ATTR_GPIO, default=False): vol.Boolean(),


### PR DESCRIPTION
Using seccomp fails on orange pi and it's not used on rpi using resinos

Supervisor starts with seccomp profile disabled. 

We could default to True if somehow a default seccomp profile file was generated that could be used during addon startup and that is tested to work with at least core addons. 

I was not able unfortunately to generate even with the help of several tools proper error mesaages to point out exactly which system call is not working because of seccomp. 

I tries to start mosquitto and another custom addon: zigbee2mqtt. 

Unfortunately the entry point would not be called for either so the addon would fail silently. 