### PR TITLE
Add SYS_RESOURCE to list of valid privileges

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -63,7 +63,8 @@ PRIVILEGED_ALL = [
     "SYS_RAWIO",
     "IPC_LOCK",
     "SYS_TIME",
-    "SYS_NICE"
+    "SYS_NICE",
+    "SYS_RESOURCE"
 ]
 
 BASE_IMAGE = {


### PR DESCRIPTION
I'm trying to create a PulseAudio addon. In order to enable real-time scheduling, the addon minimally needs the SYS_RESOURCE capability. SYS_NICE is only sufficient for high-priority. Unfortunately, I'm experiencing lots of underruns, and strongly suspect the lack of real-time scheduling in the addon as the cause.