### PR TITLE
Change timezone handling

### DIFF
--- a/hassio/bootstrap.py
+++ b/hassio/bootstrap.py
@@ -68,7 +68,8 @@ def initialize_system_data(coresys):
     # homeassistant config folder
     if not config.path_homeassistant.is_dir():
         _LOGGER.info(
-            "Create Home-Assistant config folder %s", config.path_homeassistant)
+            "Create Home-Assistant config folder %s",
+            config.path_homeassistant)
         config.path_homeassistant.mkdir()
 
     # hassio ssl folder

--- a/hassio/bootstrap.py
+++ b/hassio/bootstrap.py
@@ -66,10 +66,10 @@ def initialize_system_data(coresys):
     config = coresys.config
 
     # homeassistant config folder
-    if not config.path_config.is_dir():
+    if not config.path_homeassistant.is_dir():
         _LOGGER.info(
-            "Create Home-Assistant config folder %s", config.path_config)
-        config.path_config.mkdir()
+            "Create Home-Assistant config folder %s", config.path_homeassistant)
+        config.path_homeassistant.mkdir()
 
     # hassio ssl folder
     if not config.path_ssl.is_dir():

--- a/hassio/config.py
+++ b/hassio/config.py
@@ -50,7 +50,7 @@ class CoreConfig(JsonConfig):
             assert config_file.exists()
             configuration = config_file.read_text()
 
-            data = RE_TIMEZONE.find(configuration)
+            data = RE_TIMEZONE.search(configuration)
             assert data
 
             timezone = data.get('timezone')

--- a/hassio/config.py
+++ b/hassio/config.py
@@ -32,7 +32,7 @@ APPARMOR_DATA = PurePath("apparmor")
 
 DEFAULT_BOOT_TIME = datetime.utcfromtimestamp(0).isoformat()
 
-RE_TIMEZONE = re.compile(r"time_zone: (?P<timezone>[\w/\-+]*)")
+RE_TIMEZONE = re.compile(r"time_zone: (?P<timezone>[\w/\-+]+)")
 
 
 class CoreConfig(JsonConfig):
@@ -53,7 +53,7 @@ class CoreConfig(JsonConfig):
             data = RE_TIMEZONE.search(configuration)
             assert data
 
-            timezone = data.get('timezone')
+            timezone = data('timezone')
             pytz.timezone(timezone)
         except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
             _LOGGER.debug("Can't parse HomeAssistant timezone")

--- a/hassio/config.py
+++ b/hassio/config.py
@@ -53,7 +53,7 @@ class CoreConfig(JsonConfig):
             data = RE_TIMEZONE.search(configuration)
             assert data
 
-            timezone = data('timezone')
+            timezone = data.group('timezone')
             pytz.timezone(timezone)
         except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
             _LOGGER.debug("Can't parse HomeAssistant timezone")

--- a/hassio/config.py
+++ b/hassio/config.py
@@ -2,7 +2,10 @@
 from datetime import datetime
 import logging
 import os
+import re
 from pathlib import Path, PurePath
+
+import pytz
 
 from .const import (
     FILE_HASSIO_CONFIG, HASSIO_DATA, ATTR_TIMEZONE, ATTR_ADDONS_CUSTOM_LIST,
@@ -29,6 +32,8 @@ APPARMOR_DATA = PurePath("apparmor")
 
 DEFAULT_BOOT_TIME = datetime.utcfromtimestamp(0).isoformat()
 
+RE_TIMEZONE = re.compile(r"time_zone: (?P<timezone>[\w/\-+]*)")
+
 
 class CoreConfig(JsonConfig):
     """Hold all core config data."""
@@ -40,7 +45,21 @@ class CoreConfig(JsonConfig):
     @property
     def timezone(self):
         """Return system timezone."""
-        return self._data[ATTR_TIMEZONE]
+        config_file = Path(self.path_homeassistant, 'configuration.yaml')
+        try:
+            assert config_file.exists()
+            configuration = config_file.read_text()
+
+            data = RE_TIMEZONE.find(configuration)
+            assert data
+
+            timezone = data.get('timezone')
+            pytz.timezone(timezone)
+        except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
+            _LOGGER.debug("Can't parse HomeAssistant timezone")
+            return self._data[ATTR_TIMEZONE]
+
+        return timezone
 
     @timezone.setter
     def timezone(self, value):

--- a/hassio/config.py
+++ b/hassio/config.py
@@ -83,12 +83,12 @@ class CoreConfig(JsonConfig):
         return PurePath(os.environ['SUPERVISOR_SHARE'])
 
     @property
-    def path_extern_config(self):
+    def path_extern_homeassistant(self):
         """Return config path extern for docker."""
         return str(PurePath(self.path_extern_hassio, HOMEASSISTANT_CONFIG))
 
     @property
-    def path_config(self):
+    def path_homeassistant(self):
         """Return config path inside supervisor."""
         return Path(HASSIO_DATA, HOMEASSISTANT_CONFIG)
 

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -69,7 +69,7 @@ class CoreSys:
     @property
     def timezone(self):
         """Return timezone."""
-        return self._homeassistant.timezone or self._config.timezone
+        return self._config.timezone
 
     @property
     def loop(self):

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -70,7 +70,7 @@ class CoreSys:
     def timezone(self):
         """Return timezone."""
         hass_timezone = self._homeassistant.timezone
-        if hass_timezone != 'UTC':
+        if hass_timezone:
             return hass_timezone
         return self._config.timezone
 

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -67,6 +67,14 @@ class CoreSys:
         return self._updater.channel == CHANNEL_DEV
 
     @property
+    def timezone(self):
+        """Return timezone."""
+        hass_timezone = self._homeassistant.timezone
+        if hass_timezone != 'UTC':
+            return hass_timezone
+        return self._config.timezone
+
+    @property
     def loop(self):
         """Return loop object."""
         return self._loop

--- a/hassio/coresys.py
+++ b/hassio/coresys.py
@@ -69,10 +69,7 @@ class CoreSys:
     @property
     def timezone(self):
         """Return timezone."""
-        hass_timezone = self._homeassistant.timezone
-        if hass_timezone:
-            return hass_timezone
-        return self._config.timezone
+        return self._homeassistant.timezone or self._config.timezone
 
     @property
     def loop(self):

--- a/hassio/docker/addon.py
+++ b/hassio/docker/addon.py
@@ -173,7 +173,7 @@ class DockerAddon(DockerInterface):
         # setup config mappings
         if MAP_CONFIG in addon_mapping:
             volumes.update({
-                str(self.sys_config.path_extern_config): {
+                str(self.sys_config.path_extern_homeassistant): {
                     'bind': "/config", 'mode': addon_mapping[MAP_CONFIG]
                 }})
 

--- a/hassio/docker/addon.py
+++ b/hassio/docker/addon.py
@@ -86,7 +86,7 @@ class DockerAddon(DockerInterface):
 
         return {
             **addon_env,
-            ENV_TIME: self.sys_config.timezone,
+            ENV_TIME: self.sys_timezone,
             ENV_TOKEN: self.addon.uuid,
         }
 

--- a/hassio/docker/homeassistant.py
+++ b/hassio/docker/homeassistant.py
@@ -61,7 +61,7 @@ class DockerHomeAssistant(DockerInterface):
             network_mode='host',
             environment={
                 'HASSIO': self.sys_docker.network.supervisor,
-                ENV_TIME: self.sys_config.timezone,
+                ENV_TIME: self.sys_timezone,
                 ENV_TOKEN: self.sys_homeassistant.uuid,
             },
             volumes={
@@ -95,7 +95,7 @@ class DockerHomeAssistant(DockerInterface):
             stdout=True,
             stderr=True,
             environment={
-                ENV_TIME: self.sys_config.timezone,
+                ENV_TIME: self.sys_timezone,
             },
             volumes={
                 str(self.sys_config.path_extern_config):

--- a/hassio/docker/homeassistant.py
+++ b/hassio/docker/homeassistant.py
@@ -65,7 +65,7 @@ class DockerHomeAssistant(DockerInterface):
                 ENV_TOKEN: self.sys_homeassistant.uuid,
             },
             volumes={
-                str(self.sys_config.path_extern_config):
+                str(self.sys_config.path_extern_homeassistant):
                     {'bind': '/config', 'mode': 'rw'},
                 str(self.sys_config.path_extern_ssl):
                     {'bind': '/ssl', 'mode': 'ro'},
@@ -98,7 +98,7 @@ class DockerHomeAssistant(DockerInterface):
                 ENV_TIME: self.sys_timezone,
             },
             volumes={
-                str(self.sys_config.path_extern_config):
+                str(self.sys_config.path_extern_homeassistant):
                     {'bind': '/config', 'mode': 'rw'},
                 str(self.sys_config.path_extern_ssl):
                     {'bind': '/ssl', 'mode': 'ro'},

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -22,7 +22,7 @@ from .docker.homeassistant import DockerHomeAssistant
 from .exceptions import (
     HomeAssistantUpdateError, HomeAssistantError, HomeAssistantAPIError,
     HomeAssistantAuthError)
-from .utils import convert_to_ascii, process_lock
+from .utils import convert_to_ascii, process_lock, dt
 from .utils.json import JsonConfig
 from .validate import SCHEMA_HASS_CONFIG
 
@@ -205,10 +205,12 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
             group = RE_TIMEZONE.find(configuration)
             assert group
 
-            return group.get(timezone, 'UTC')
+            return dt.validate_timezone(group.get(timezone, 'UTC'))
         except OSError:
             _LOGGER.warning("Can't read configuration")
         except AssertionError:
+            pass
+        except HomeAssistantError:
             pass
 
         return 'UTC'

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -207,7 +207,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
             group = RE_TIMEZONE.find(configuration)
             assert group
 
-            timezone = group.get('timezone', 'UTC')
+            timezone = group.get('timezone')
             pytz.timezone(timezone)
             return timezone
         except OSError:

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -4,7 +4,6 @@ from contextlib import asynccontextmanager, suppress
 import logging
 import os
 import re
-from pathlib import Path
 import socket
 import time
 

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -209,11 +209,11 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
 
             timezone = data.get('timezone')
             pytz.timezone(timezone)
-            return timezone
         except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
             _LOGGER.debug("Can't parse HomeAssistant timezone")
+            return None
 
-        return None
+        return timezone
 
     @process_lock
     async def install_landingpage(self):

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -204,18 +204,14 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
             assert config_file.exists()
             configuration = config_file.read_text()
 
-            group = RE_TIMEZONE.search(configuration)
-            assert group
+            data = RE_TIMEZONE.match(configuration)
+            assert data
 
-            timezone = group.get('timezone')
+            timezone = data.get('timezone')
             pytz.timezone(timezone)
             return timezone
-        except OSError:
-            _LOGGER.warning("Can't read configuration")
-        except AssertionError:
-            pass
-        except pytz.exceptions.UnknownTimeZoneError:
-            _LOGGER.warning("Invalid timezone: %s", timezone)
+        except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
+            _LOGGER.debug("Can't parse HomeAssistant timezone")
 
         return None
 

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -30,7 +30,7 @@ from .validate import SCHEMA_HASS_CONFIG
 _LOGGER = logging.getLogger(__name__)
 
 RE_YAML_ERROR = re.compile(r"homeassistant\.util\.yaml")
-RE_TIMEZONE = re.compile(r"timezone: (?P<timezone>[\w/\-+]*)")
+RE_TIMEZONE = re.compile(r"time_zone: (?P<timezone>[\w/\-+]*)")
 
 # pylint: disable=invalid-name
 ConfigResult = attr.make_class('ConfigResult', ['valid', 'log'], frozen=True)

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -204,7 +204,7 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
             assert config_file.exists()
             configuration = config_file.read_text()
 
-            group = RE_TIMEZONE.find(configuration)
+            group = RE_TIMEZONE.search(configuration)
             assert group
 
             timezone = group.get('timezone')

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -30,7 +30,7 @@ from .validate import SCHEMA_HASS_CONFIG
 _LOGGER = logging.getLogger(__name__)
 
 RE_YAML_ERROR = re.compile(r"homeassistant\.util\.yaml")
-RE_TIMEZONE = re.compile(r"timezone: (?P<timezone>[\w/\-+]*")
+RE_TIMEZONE = re.compile(r"timezone: (?P<timezone>[\w/\-+]*)")
 
 # pylint: disable=invalid-name
 ConfigResult = attr.make_class('ConfigResult', ['valid', 'log'], frozen=True)

--- a/hassio/homeassistant.py
+++ b/hassio/homeassistant.py
@@ -11,7 +11,6 @@ import time
 import aiohttp
 from aiohttp import hdrs
 import attr
-import pytz
 
 from .const import (
     FILE_HASSIO_HOMEASSISTANT, ATTR_IMAGE, ATTR_LAST_VERSION, ATTR_UUID,
@@ -30,7 +29,6 @@ from .validate import SCHEMA_HASS_CONFIG
 _LOGGER = logging.getLogger(__name__)
 
 RE_YAML_ERROR = re.compile(r"homeassistant\.util\.yaml")
-RE_TIMEZONE = re.compile(r"time_zone: (?P<timezone>[\w/\-+]*)")
 
 # pylint: disable=invalid-name
 ConfigResult = attr.make_class('ConfigResult', ['valid', 'log'], frozen=True)
@@ -194,26 +192,6 @@ class HomeAssistant(JsonConfig, CoreSysAttributes):
     def refresh_token(self, value):
         """Set Home Assistant refresh_token."""
         self._data[ATTR_REFRESH_TOKEN] = value
-
-    @property
-    def timezone(self):
-        """Read timezone from config."""
-        config_file = Path(
-            self.sys_config.path_homeassistant, 'configuration.yaml')
-        try:
-            assert config_file.exists()
-            configuration = config_file.read_text()
-
-            data = RE_TIMEZONE.match(configuration)
-            assert data
-
-            timezone = data.get('timezone')
-            pytz.timezone(timezone)
-        except (pytz.exceptions.UnknownTimeZoneError, OSError, AssertionError):
-            _LOGGER.debug("Can't parse HomeAssistant timezone")
-            return None
-
-        return timezone
 
     @process_lock
     async def install_landingpage(self):

--- a/hassio/utils/dt.py
+++ b/hassio/utils/dt.py
@@ -9,7 +9,6 @@ UTC = pytz.utc
 
 _LOGGER = logging.getLogger(__name__)
 
-FREEGEOIP_URL = "https://freegeoip.net/json/"
 
 # Copyright (c) Django Software Foundation and individual contributors.
 # All rights reserved.


### PR DESCRIPTION
Fix:  #638

We used before a free geo ip service to evulate the timezone before home-assistant was able to tell us the correct timezone. Now this service is not anymore free and we had need remove it.

With this change, it should work a bit like with this service and should fix some misshandling with timezone