### PR TITLE
Adds venv to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,7 @@
 
 # Temporary files
 **/__pycache__
+
+# virtualenv
+venv/
+ENV/


### PR DESCRIPTION
Add virtual environments to the `.dockerignore` file.

This prevents the virtual env from being transferred into the Docker image/build.