### PR TITLE
Fixes a typo in method name

### DIFF
--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -608,7 +608,7 @@ class Addon(CoreSysAttributes):
             return vol.Schema(dict)
         return vol.Schema(vol.All(dict, validate_options(raw_schema)))
 
-    def test_udpate_schema(self):
+    def test_update_schema(self):
         """Check if the exists config valid after update."""
         if not self.is_installed or self.is_detached:
             return True

--- a/hassio/tasks.py
+++ b/hassio/tasks.py
@@ -67,7 +67,7 @@ class Tasks(CoreSysAttributes):
             if addon.version_installed == addon.last_version:
                 continue
 
-            if addon.test_udpate_schema():
+            if addon.test_update_schema():
                 tasks.append(addon.update())
             else:
                 _LOGGER.warning(


### PR DESCRIPTION
Fixes a small typo in a method name.

`test_udpate_schema` -> `test_update_schema`

