### PR TITLE
WIP: Adds devices existence checks before using

### DIFF
--- a/hassio/docker/addon.py
+++ b/hassio/docker/addon.py
@@ -1,10 +1,10 @@
 """Init file for HassIO addon docker object."""
 import logging
 import os
+import re
 from pathlib import Path
 
 import docker
-import re
 import requests
 
 from .interface import DockerInterface
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 AUDIO_DEVICE = "/dev/snd:/dev/snd:rwm"
 RE_DEVICE = re.compile(r"^(?P<device>.*?):")
+
 
 class DockerAddon(DockerInterface):
     """Docker hassio wrapper for HomeAssistant."""


### PR DESCRIPTION
Check devices if they exist before actually using them.

This allows an add-on developer to specify devices that might not be available on all platforms.
For example: We could add the Raspberry camera device to the SSH add-on, without breaking it on other platforms.

Fixes: #656
Ref: #184
