### PR TITLE
Fix machine 'odroid-c2'

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -61,7 +61,7 @@ ARCH_ALL = [
 MACHINE_ALL = [
     'intel-nuc', 'qemux86', 'qemux86-64', 'qemuarm', 'qemuarm-64',
     'raspberrypi', 'raspberrypi2', 'raspberrypi3', 'raspberrypi3-64',
-    'odroid-cu2', 'odroid-xu',
+    'odroid-c2', 'odroid-xu',
 ]
 
 STARTUP_ALL = [


### PR DESCRIPTION
Odroid-cu2 does not exist AFAIK, it needs to be c2.

Fixes related add-on install issue: https://github.com/hassio-addons/addon-motioneye/issues/1