### PR TITLE
Add missing tinker board

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -61,7 +61,7 @@ ARCH_ALL = [
 MACHINE_ALL = [
     'intel-nuc', 'qemux86', 'qemux86-64', 'qemuarm', 'qemuarm-64',
     'raspberrypi', 'raspberrypi2', 'raspberrypi3', 'raspberrypi3-64',
-    'odroid-c2', 'odroid-xu',
+    'tinker', 'odroid-c2', 'odroid-xu',
 ]
 
 STARTUP_ALL = [


### PR DESCRIPTION
Since I can't install a new add-on since hassio release 134 because of error 'addon not supported on armhf'. I think that support for tinker board is missing