### PR TITLE
Expand error message

### DIFF
--- a/hassio/addons/addon.py
+++ b/hassio/addons/addon.py
@@ -674,7 +674,7 @@ class Addon(CoreSysAttributes):
         """Install an add-on."""
         if not self.available:
             _LOGGER.error(
-                "Add-on %s not supported on %s", self._id, self.sys_arch)
+                "Add-on %s not supported on %s with %s architecture", self._id, self.sys_machine, self.sys_arch)
             return False
 
         if self.is_installed:


### PR DESCRIPTION
Since an add-on is only available for certain machine and architecture combination we should log both.