### PR TITLE
Bugfix Add-on validate correct image url

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -160,7 +160,7 @@ SCHEMA_ADDON_CONFIG = vol.Schema({
         }))
     }), False),
     vol.Optional(ATTR_IMAGE):
-        vol.Match(r"^([a-zA-Z.:\d{}]+/)*?([\w{}]+)/([\-\w{}]+)$"),
+        vol.Match(r"^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)$"),
     vol.Optional(ATTR_TIMEOUT, default=10):
         vol.All(vol.Coerce(int), vol.Range(min=10, max=120)),
 }, extra=vol.REMOVE_EXTRA)

--- a/tests/addons/test_config.py
+++ b/tests/addons/test_config.py
@@ -29,13 +29,26 @@ def test_basic_config():
 
 
 def test_invalid_repository():
-    """Validate basic config with invalid repository."""
+    """Validate basic config with invalid repositories."""
     config = load_json_fixture("basic-addon-config.json")
 
-    config['image'] = "home-assistant/no-valid-repo"
+    config['image'] = "something"
     with pytest.raises(vol.Invalid):
         vd.SCHEMA_ADDON_CONFIG(config)
 
     config['image'] = "homeassistant/no-valid-repo:no-tag-allow"
     with pytest.raises(vol.Invalid):
         vd.SCHEMA_ADDON_CONFIG(config)
+
+    config['image'] = "registry.gitlab.com/company/add-ons/test-example/text-example:no-tag-allow"
+    with pytest.raises(vol.Invalid):
+        vd.SCHEMA_ADDON_CONFIG(config)
+
+def test_valid_repository():
+    """Validate basic config with different valid repositories"""
+    config = load_json_fixture("basic-addon-config.json")
+
+    custom_registry = "registry.gitlab.com/company/add-ons/core/test-example"
+    config['image'] = custom_registry
+    valid_config = vd.SCHEMA_ADDON_CONFIG(config)
+    assert valid_config['image'] == custom_registry


### PR DESCRIPTION
At the moment you can not install an add-on with an image value like `registry.gitlab.com/company/add-ons/demo-service/demo-service`

See [Regex101](https://regex101.com/r/8DQgL4/1/) for further details.