### PR TITLE
Add support for the Orange Pi Prime

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -60,9 +60,12 @@ ARCH_ALL = [
 ]
 
 MACHINE_ALL = [
-    'intel-nuc', 'qemux86', 'qemux86-64', 'qemuarm', 'qemuarm-64',
+    'intel-nuc',
+    'odroid-c2', 'odroid-xu',
+    'orangepi-prime',
+    'qemux86', 'qemux86-64', 'qemuarm', 'qemuarm-64',
     'raspberrypi', 'raspberrypi2', 'raspberrypi3', 'raspberrypi3-64',
-    'tinker', 'odroid-c2', 'odroid-xu',
+    'tinker',
 ]
 
 STARTUP_ALL = [


### PR DESCRIPTION
This PR sorts the machine list alphabetically, and adds support for the Orange Pi Prime