### PR TITLE
Add generic platforms

### DIFF
--- a/hassio/addons/validate.py
+++ b/hassio/addons/validate.py
@@ -60,6 +60,7 @@ ARCH_ALL = [
 ]
 
 MACHINE_ALL = [
+    'generic-aarch64', 'generic-amd64', 'generic-armhf', 'generic-i386',
     'intel-nuc',
     'odroid-c2', 'odroid-xu',
     'orangepi-prime',


### PR DESCRIPTION
Thinking a bit more about @pvizeli 's suggestion about 'orangepi-h5', I came to the conclusion that having some clearly labelled generic platforms would be helpful.

I spent quite some trying trying to figure out how the specify which machine to use on my (then unsupported) Orange Pi Prime, before realising that the qemu machine was fairly generic.

This patch adds some generic platforms that can either be used outright, or as a template for new boards.