### PR TITLE
Revert "Delete move.yml"

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,13 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment. Ignored when the comment also contains other content
+deleteCommand: true
+# Close the source issue after moving
+closeSourceIssue: true
+# Lock the source issue after moving
+lockSourceIssue: false
+# Set custom aliases for targets
+# aliases:
+#   r: repo
+#   or: owner/repo
+


### PR DESCRIPTION
This reverts commit 07c4058a8c74d3eb852de5e5095ad186585d60aa.

Re-enabling the probot movebot again to allow for non-admins to move issues between repos.