### PR TITLE
Include serial device node links in container device mapping to allow…

### DIFF
--- a/hassio/misc/hardware.py
+++ b/hassio/misc/hardware.py
@@ -38,6 +38,7 @@ class Hardware:
         for device in self.context.list_devices(subsystem='tty'):
             if 'ID_VENDOR' in device or RE_TTY.search(device.device_node):
                 dev_list.add(device.device_node)
+                dev_list.extend(device.device_links)
 
         return dev_list
 


### PR DESCRIPTION
… for persistent names in the HA serial config

This is intended as a fix for issue #911 and I might have managed to compile test it but no more.

I claim no credit for it either, kpine came up with the solution in the issue discussion.