### PR TITLE
Downgrade add-on API access logging to debug

### DIFF
--- a/hassio/api/proxy.py
+++ b/hassio/api/proxy.py
@@ -35,7 +35,7 @@ class APIProxy(CoreSysAttributes):
         elif not addon.access_homeassistant_api:
             _LOGGER.warning("Not permitted API access: %s", addon.slug)
         else:
-            _LOGGER.info("%s access from %s", request.path, addon.slug)
+            _LOGGER.debug("%s access from %s", request.path, addon.slug)
             return
 
         raise HTTPUnauthorized()


### PR DESCRIPTION
Access to the API from add-ons is logged with every request, which spams the supervisor logs for add-ons that access it frequently, eg if they update sensors or poll state.  This downgrades the logging for such requests from 'info' to 'debug'
resolves home-assistant/hassio#865