### PR TITLE
Remove potential tag when pulling new image

### DIFF
--- a/hassio/docker/interface.py
+++ b/hassio/docker/interface.py
@@ -78,6 +78,7 @@ class DockerInterface(CoreSysAttributes):
         Need run inside executor.
         """
         image = image or self.image
+        image = image.partition(':')[0]  # remove potential tag
 
         try:
             _LOGGER.info("Pull image %s tag %s.", image, tag)


### PR DESCRIPTION
Fixes #1018 by removing tag if it exist in the image name.