### PR TITLE
Fix device bug

### DIFF
--- a/hassio/addons/model.py
+++ b/hassio/addons/model.py
@@ -257,7 +257,7 @@ class AddonModel(CoreSysAttributes):
     @property
     def devices(self) -> Optional[List[str]]:
         """Return devices of add-on."""
-        return self.data.get(ATTR_DEVICES)
+        return self.data.get(ATTR_DEVICES, [])
 
     @property
     def auto_uart(self) -> bool:

--- a/hassio/docker/addon.py
+++ b/hassio/docker/addon.py
@@ -126,7 +126,11 @@ class DockerAddon(DockerInterface):
     @property
     def devices(self) -> List[str]:
         """Return needed devices."""
-        devices = self.addon.devices or []
+        devices = []
+
+        # Extend add-on config
+        if self.addon.devices:
+            devices.extend(self.addon.devices)
 
         # Use audio devices
         if self.addon.with_audio and self.sys_hardware.support_audio:


### PR DESCRIPTION
Fix bug after restoring or unplug devices like: 
```
[hassio.docker] Can't start xxx: 500 Server Error: Internal Server Error ("linux runtime spec devices: error gathering device information while adding custom device "/dev/ttyACM0": no such file or directory")
```