### PR TITLE
Fix error on add-on comparing

### DIFF
--- a/hassio/addons/model.py
+++ b/hassio/addons/model.py
@@ -449,9 +449,9 @@ class AddonModel(CoreSysAttributes):
 
     def __eq__(self, other):
         """Compaired add-on objects."""
-        if self.slug == other.slug:
-            return True
-        return False
+        if not isinstance(other, AddonModel):
+            return False
+        return self.slug == other.slug
 
     def _available(self, config) -> bool:
         """Return True if this add-on is available on this platform."""


### PR DESCRIPTION
```
File "/usr/local/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/src/hassio/hassio/api/security.py", line 144, in token_validation
    return await handler(request)
  File "/usr/src/hassio/hassio/api/utils.py", line 32, in wrap_api
    answer = await method(api, *args, **kwargs)
  File "/usr/src/hassio/hassio/api/discovery.py", line 44, in list
    self._check_permission_ha(request)
  File "/usr/src/hassio/hassio/api/discovery.py", line 38, in _check_permission_ha
    if request[REQUEST_FROM] != self.sys_homeassistant:
  File "/usr/src/hassio/hassio/addons/model.py", line 452, in __eq__
    if self.slug == other.slug:
AttributeError: 'HomeAssistant' object has no attribute 'slug'
```