### PR TITLE
Support for AdGuard Home discovery

### DIFF
--- a/hassio/discovery/services/adguard.py
+++ b/hassio/discovery/services/adguard.py
@@ -1,0 +1,14 @@
+"""Discovery service for AdGuard."""
+import voluptuous as vol
+
+from hassio.validate import NETWORK_PORT
+
+from ..const import ATTR_HOST, ATTR_PORT
+
+
+SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_HOST): vol.Coerce(str),
+        vol.Required(ATTR_PORT): NETWORK_PORT
+    }
+)

--- a/hassio/discovery/services/adguard.py
+++ b/hassio/discovery/services/adguard.py
@@ -7,8 +7,5 @@ from ..const import ATTR_HOST, ATTR_PORT
 
 
 SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_HOST): vol.Coerce(str),
-        vol.Required(ATTR_PORT): NETWORK_PORT
-    }
+    {vol.Required(ATTR_HOST): vol.Coerce(str), vol.Required(ATTR_PORT): NETWORK_PORT}
 )


### PR DESCRIPTION
Adds support for discovery of the `adguard` integration of Home Assistant.

Parent PR: home-assistant/home-assistant#24219