### PR TITLE
enable armv7 and armhf for qemuarm-64 machine

### DIFF
--- a/hassio/arch.json
+++ b/hassio/arch.json
@@ -49,7 +49,9 @@
         "armhf"
     ],
     "qemuarm-64": [
-        "aarch64"
+        "aarch64",
+        "armv7",
+        "armhf"
     ],
     "intel-nuc": [
         "amd64",


### PR DESCRIPTION
The aarc64 Qemu machine supports the 32-bit ARM state as well. This
is also useful since this machine is used on machines without an
official machine architecture in hass.io.