### PR TITLE
WIP: Only connect to D-Bus interface for rauc on HassOS

### DIFF
--- a/hassio/dbus/__init__.py
+++ b/hassio/dbus/__init__.py
@@ -15,7 +15,7 @@ class DBusManager(CoreSysAttributes):
 
         self._systemd = Systemd()
         self._hostname = Hostname()
-        self._rauc = Rauc()
+        self._rauc = Rauc(coresys)
 
     @property
     def systemd(self):


### PR DESCRIPTION
This stops Hass.io from connecting to the D-Bus interface for rauc, which causes a warning in the logs for non-HassOS users. While cosmetic, it throws off a lot of new users.

This PR checks if the underlying system is actually HassOS, before continuing connecting.
If the host is HassOS, the behavior is unchanged and it will still throw the warning when the connection fails.

Implementation decision reasoning: I've passed in coresys, which might be overkill, however, it does match the general pattern in the codebase. Another option is passing in the D-Bus hostname instance directly (since it actually only depends on that).

Fixes #560