### PR TITLE
Allow manager role to access DNS API

### DIFF
--- a/hassio/api/security.py
+++ b/hassio/api/security.py
@@ -67,6 +67,7 @@ ADDONS_ROLE_ACCESS = {
     ),
     ROLE_MANAGER: re.compile(
         r"^(?:"
+        r"|/dns/.*"
         r"|/homeassistant/.+"
         r"|/host/.+"
         r"|/hardware/.+"


### PR DESCRIPTION
With this, the CLI will not work (of course).