### PR TITLE
Restart CoreDNS on upstream servers change

### DIFF
--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -63,6 +63,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
     def servers(self, value: List[str]) -> None:
         """Return list of DNS servers."""
         self._data[ATTR_SERVERS] = value
+        self.sys_create_task(self.restart())
 
     @property
     def version(self) -> Optional[str]:


### PR DESCRIPTION
After the upstream DNS servers are changed by the user (e.g., via the CLI), Hassio DNS needs to be restarted in order to write new CoreDNS config file and restart the container.

The solution provided is a quick and short one (but valid, since we have just 1 option to set at this point), however, we might want to change this behavior in the future in a more generic way.

Command run using hass.io CLI: `hassio dns opts --servers dns://10.10.100.10`

Log output of the new situation:

```
19-08-17 11:34:04 INFO (MainThread) [hassio.api.security] /dns/options access from a0d7b954_ssh
19-08-17 11:34:04 INFO (SyncWorker_4) [hassio.docker.interface] Stop hassio_dns application
19-08-17 11:34:04 INFO (SyncWorker_4) [hassio.docker.interface] Clean hassio_dns application
19-08-17 11:34:04 INFO (MainThread) [hassio.dns] Start CoreDNS plugin
19-08-17 11:34:07 INFO (SyncWorker_9) [hassio.docker.dns] Start DNS homeassistant/amd64-hassio-dns with version 1
```

Resulting corefile:
```
root@3f41ddf109f2:/workspaces/test_hassio/dns# cat corefile 
.:53 {
    log
    hosts /config/hosts {
        fallthrough
    }
    forward . dns://10.10.100.10 dns://8.8.8.8 dns://1.1.1.1 {
        health_check 10s
    }
}
```
