### PR TITLE
Replace Google DNS by Quad9, prefer CloudFlare

### DIFF
--- a/hassio/const.py
+++ b/hassio/const.py
@@ -32,7 +32,7 @@ DOCKER_NETWORK = "hassio"
 DOCKER_NETWORK_MASK = ip_network("172.30.32.0/23")
 DOCKER_NETWORK_RANGE = ip_network("172.30.33.0/24")
 
-DNS_SERVERS = ["dns://8.8.8.8", "dns://1.1.1.1"]
+DNS_SERVERS = ["dns://1.1.1.1", "dns://9.9.9.9"]
 DNS_SUFFIX = "local.hass.io"
 
 LABEL_VERSION = "io.hass.version"


### PR DESCRIPTION
Currently, the Hass.io DNS falls back to Google DNS & CloudFlare's one dot one dot one dot one.

Just hours after releasing Hassio DNS, people started commenting on the privacy concerns with Google DNS. 

This PR is addressing this privacy concern, by changing the defaults to the 2 biggest privacy-aware DNS providers out there: CloudFlare & Quad9. Both have an excellent track record. 

Cloudflare is considered the fastest DNS server in the world (based on dozens of different benchmarks), hence I've moved it to be the first one. Quad9 has about the same response speed as Google DNS, hence I've added Quad9 as a second.

TL;DR: Replace Google DNS by Quad9 in order to address possible privacy concerns.