### PR TITLE
Adjust coredns do not forward local.hass.io

### DIFF
--- a/hassio/data/coredns.tmpl
+++ b/hassio/data/coredns.tmpl
@@ -4,6 +4,7 @@
         fallthrough
     }
     forward . $servers {
+        except local.hass.io
         health_check 10s
     }
 }


### PR DESCRIPTION
Right now, `local.hassio.io` forwards to upstream DNS servers, however, it should not.
The `hass.io` domain has a wildcard on AWS, which now results in looking up `sdjhfkjdshfjkdsks` (random) on a Hass.io box, resolves to AWS.

This PR prevents that by excluding `local.hass.io` from forwarding.