### PR TITLE
Adjust coredns to use upstream fowarding server in order

### DIFF
--- a/hassio/data/coredns.tmpl
+++ b/hassio/data/coredns.tmpl
@@ -4,6 +4,7 @@
         fallthrough
     }
     forward . $servers {
+        policy sequential
         health_check 10s
     }
 }


### PR DESCRIPTION
When using CoreDNS with the forward plugin; Multiple upstreams are randomized on first use.
This causes one of the configured or provided upstream server to be selected, which can be a bit unexpected. A user-provided server should be used first, the standard provided servers as a fallback.

From the documentation:

---
* `policy` specifies the policy to use for selecting upstream servers. The default is `random`.
  * `random` is a policy that implements random upstream selection.
  * `round_robin` is a policy that selects hosts based on round robin ordering.
  * `sequential` is a policy that selects hosts based on sequential ordering.
---


I've adjusted this policy to be `sequential` in this PR. 