### PR TITLE
Allow default DNS servers to be a fallback.

### DIFF
--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -223,9 +223,9 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
         #
         # 3. if there are no manual and no local defined use the default
         # servers.
-        if len(self.servers) > 0:
+        if self.servers:
             possible_dns_servers = self.servers
-        elif len(self.sys_host.network.dns_servers) > 0:
+        elif self.sys_host.network.dns_servers:
             possible_dns_servers = self.sys_host.network.dns_servers
         else:
             possible_dns_servers = DNS_SERVERS


### PR DESCRIPTION
This change set the priority of the DNS servers.

The logic is as follows:

1. If there are manually defined servers use those.  The end user has
manually set what the DNS servers should be and that should be honored.

2. If there are no manually defined DNS servers, use the local host
defined. Of note, Not all os types use NetworkManager and dbus so this
can show up empty

3. If there are no manual or no local host based DNS servers defined
use the default servers.

This will provide that the DNS should always be set to the users
preferences and only include the external cloud based ones if all other
options have been excluded.

This would address issues brought up in #1251.