### PR TITLE
Add support for Home Panel Discovery

### DIFF
--- a/hassio/discovery/services/home_panel.py
+++ b/hassio/discovery/services/home_panel.py
@@ -1,0 +1,11 @@
+"""Discovery service for Home Panel."""
+import voluptuous as vol
+
+from hassio.validate import NETWORK_PORT
+
+from ..const import ATTR_HOST, ATTR_PORT
+
+
+SCHEMA = vol.Schema(
+    {vol.Required(ATTR_HOST): vol.Coerce(str), vol.Required(ATTR_PORT): NETWORK_PORT}
+)


### PR DESCRIPTION
Adds support for `home_panel` discovery in Home Assistant.

Related PR: home-assistant/home-assistant#27540