### PR TITLE
Gracefully allow loading duplicate keys in secrets

### DIFF
--- a/hassio/secrets.py
+++ b/hassio/secrets.py
@@ -50,6 +50,7 @@ class SecretsManager(CoreSysAttributes):
         # Read secrets
         try:
             yaml = YAML()
+            yaml.allow_duplicate_keys = True
             data = await self.sys_run_in_executor(yaml.load, self.path_secrets) or {}
 
             # Filter to only get supported values


### PR DESCRIPTION
Gracefully allow for duplicate keys in secrets to prevent issues when a user has mistakenly added a duplicate secret.

Closes #1333